### PR TITLE
Fix incorrect handling of CRLF

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# http://EditorConfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.crlf.*]
+end_of_line = crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+
+*.crlf.* eol=crlf

--- a/Highlight/Language.php
+++ b/Highlight/Language.php
@@ -107,7 +107,12 @@ class Language
 
     private function langRe($value, $global=false)
     {
-        return "/{$value}/um" . ($this->caseInsensitive ? "i" : "");
+        // PCRE allows us to change the definition of "new line." The
+        // `(*ANYCRLF)` matches `\r`, `\n`, and `\r\n` for `$`
+        //
+        //   https://www.pcre.org/original/doc/html/pcrepattern.html
+
+        return "/(*ANYCRLF){$value}/um" . ($this->caseInsensitive ? "i" : "");
     }
 
     private function processKeyWords($kw)

--- a/test/SpecialTest.php
+++ b/test/SpecialTest.php
@@ -72,4 +72,14 @@ class SpecialTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($data->expected, $actual->value);
     }
+
+    public function testWindowsCRLF()
+    {
+        $hl = new Highlighter();
+
+        $data = $this->getTestData("line-endings.crlf");
+        $actual = $hl->highlight("js", $data->code);
+
+        $this->assertEquals($data->expected, $actual->value);
+    }
 }

--- a/test/special/line-endings.crlf.expect.txt
+++ b/test/special/line-endings.crlf.expect.txt
@@ -1,0 +1,4 @@
+<span class="hljs-comment">// FileComponent Class</span>
+<span class="hljs-keyword">export</span> <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">FileComponent</span> </span>{
+    file = { <span class="hljs-attr">name</span>: <span class="hljs-string">'logo.svg'</span>, <span class="hljs-attr">size</span>: <span class="hljs-number">2120109</span>, <span class="hljs-attr">type</span>: <span class="hljs-string">'image/svg'</span> };
+}

--- a/test/special/line-endings.crlf.txt
+++ b/test/special/line-endings.crlf.txt
@@ -1,0 +1,4 @@
+// FileComponent Class
+export class FileComponent {
+    file = { name: 'logo.svg', size: 2120109, type: 'image/svg' };
+}


### PR DESCRIPTION
Seems that a `$` in our regular expressions will match `\r` in `\r\n` but it'll forget about the `\n`. This seems like expected behavior judging by [PCRE](https://www.pcre.org/original/doc/html/pcrepattern.html)'s spec which lists the order of `CR`, `LF`, `CRLF`. Using the `(*ANYCRLF)` option allows you to change this behavior, so I added it to our core `Language::langRe()` which handles all our regular expressions.

I've also added some line ending definitions to test for CRLF vs LF in the future.

Fixes #20