### PR TITLE
Ability to list available language aliases

### DIFF
--- a/Highlight/Highlighter.php
+++ b/Highlight/Highlighter.php
@@ -563,12 +563,49 @@ class Highlighter
      * setAutodetectLanguages will turn on autodetection for all supported
      * languages.
      *
+     * @param bool $include_aliase Specify whether language aliases
+     *      should be included as well.
+     *
      * @return array
      *      An array of language names (strings).
      */
-    public function listLanguages()
+    public function listLanguages($include_aliases = false)
     {
+        if ($include_aliases === true ) {
+            return array_merge(self::$languages, array_keys(self::$aliases));
+        }
+
         return self::$languages;
     }
 
+    /**
+     * Returns list of all available aliases for given language name.
+     *
+     * @param string $language Name or alias of language to look-up.
+     *
+     * @return array
+     *      An array of all aliases associated with the requested
+     *      language name language. Passed-in name is included as
+     *      well.
+     */
+    public function getAliasesForLanguage($language)
+    {
+        if (!in_array($language, self::$languages)) {
+            if (array_key_exists($language, self::$aliases)) {
+                $language = self::$aliases[$language];
+            } else {
+                throw new \DomainException("Unknown language: $language");
+            }
+        }
+
+        $aliases = [$language];
+
+        foreach (self::$aliases as $alias => $alias_for) {
+            if ($alias_for === $language) {
+                $aliases[] = $alias;
+            }
+        }
+
+        return $aliases;
+    }
 }

--- a/Highlight/Highlighter.php
+++ b/Highlight/Highlighter.php
@@ -566,7 +566,7 @@ class Highlighter
      * @param bool $include_aliases Specify whether language aliases
      *      should be included as well.
      *
-     * @return strings[]
+     * @return string[]
      *      An array of language names.
      */
     public function listLanguages($include_aliases = false)
@@ -595,8 +595,7 @@ class Highlighter
         if ($language->aliases === null) {
             return [$language->name];
         }
-        else {
-            return array_merge(array($language->name), $language->aliases);
-        }
+
+        return array_merge(array($language->name), $language->aliases);
     }
 }

--- a/Highlight/Highlighter.php
+++ b/Highlight/Highlighter.php
@@ -563,11 +563,11 @@ class Highlighter
      * setAutodetectLanguages will turn on autodetection for all supported
      * languages.
      *
-     * @param bool $include_aliase Specify whether language aliases
+     * @param bool $include_aliases Specify whether language aliases
      *      should be included as well.
      *
-     * @return array
-     *      An array of language names (strings).
+     * @return strings[]
+     *      An array of language names.
      */
     public function listLanguages($include_aliases = false)
     {
@@ -583,7 +583,7 @@ class Highlighter
      *
      * @param string $language Name or alias of language to look-up.
      *
-     * @return array
+     * @return string[]
      *      An array of all aliases associated with the requested
      *      language name language. Passed-in name is included as
      *      well.
@@ -596,7 +596,7 @@ class Highlighter
             return [$language->name];
         }
         else {
-            return array_merge([$language->name], $language->aliases);
+            return array_merge(array($language->name), $language->aliases);
         }
     }
 }

--- a/Highlight/Highlighter.php
+++ b/Highlight/Highlighter.php
@@ -590,22 +590,13 @@ class Highlighter
      */
     public function getAliasesForLanguage($language)
     {
-        if (!in_array($language, self::$languages)) {
-            if (array_key_exists($language, self::$aliases)) {
-                $language = self::$aliases[$language];
-            } else {
-                throw new \DomainException("Unknown language: $language");
-            }
+        $language = self::getLanguage($language);
+
+        if ($language->aliases === null) {
+            return [$language->name];
         }
-
-        $aliases = [$language];
-
-        foreach (self::$aliases as $alias => $alias_for) {
-            if ($alias_for === $language) {
-                $aliases[] = $alias;
-            }
+        else {
+            return array_merge([$language->name], $language->aliases);
         }
-
-        return $aliases;
     }
 }

--- a/test/HighlightTest.php
+++ b/test/HighlightTest.php
@@ -29,6 +29,7 @@
  */
 
 use Highlight\Highlighter;
+use Highlight\Language;
 
 class HighlightTest extends PHPUnit_Framework_TestCase
 {
@@ -38,5 +39,71 @@ class HighlightTest extends PHPUnit_Framework_TestCase
 
         $hl = new Highlighter();
         $hl->highlight("blah++", "als blurp eq z dan zeg 'flipper'");
+    }
+
+    public function testListLanguagesWithoutAliases()
+    {
+        $expectedLanguageCount = count(glob(__DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR .
+                                            'Highlight' . DIRECTORY_SEPARATOR . 'languages' . DIRECTORY_SEPARATOR .
+                                            '*.json'));
+
+        $hl = new Highlighter();
+
+        $availableLanguages = $hl->listLanguages();
+        $this->assertEquals($expectedLanguageCount, count($availableLanguages));
+
+        $availableLanguages = $hl->listLanguages(false);
+        $this->assertEquals($expectedLanguageCount, count($availableLanguages));
+    }
+
+    public function testListLanguagesWithAliases()
+    {
+        $minimumLanguageCount = count(glob(__DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR .
+                                           'Highlight' . DIRECTORY_SEPARATOR . 'languages' . DIRECTORY_SEPARATOR .
+                                           '*.json'));
+
+        $hl = new Highlighter();
+        $availableLanguages = $hl->listLanguages(true);
+        $this->assertGreaterThan($minimumLanguageCount, count($availableLanguages));
+    }
+
+    public function testGetAliasesForLanguageWhenUsingMainLanguageName()
+    {
+        $languageDefinitionFile = __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR .
+                                'Highlight' . DIRECTORY_SEPARATOR . 'languages' . DIRECTORY_SEPARATOR . "php.json";
+        $language = new Language('php', $languageDefinitionFile);
+        $expected_aliases = $language->aliases;
+        $expected_aliases[] = 'php';
+        sort($expected_aliases);
+
+        $hl = new Highlighter();
+        $aliases = $hl->getAliasesForLanguage('php');
+        sort($aliases);
+
+        $this->assertEquals($expected_aliases, $aliases);
+    }
+
+    public function testGetAliasesForLanguageWhenUsingLanguageAlias()
+    {
+        $languageDefinitionFile = __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR .
+                                'Highlight' . DIRECTORY_SEPARATOR . 'languages' . DIRECTORY_SEPARATOR . "php.json";
+        $language = new Language('php', $languageDefinitionFile);
+        $expected_aliases = $language->aliases;
+        $expected_aliases[] = 'php';
+        sort($expected_aliases);
+
+        $hl = new Highlighter();
+        $aliases = $hl->getAliasesForLanguage('php3');
+        sort($aliases);
+
+        $this->assertEquals($expected_aliases, $aliases);
+    }
+
+    public function testGetAliasesForLanguageRaisesExceptionForNonExistingLanguage()
+    {
+        $this->setExpectedException(DomainException::class);
+
+        $hl = new Highlighter();
+        $hl->getAliasesForLanguage('blah+');
     }
 }

--- a/test/HighlightTest.php
+++ b/test/HighlightTest.php
@@ -68,10 +68,10 @@ class HighlightTest extends PHPUnit_Framework_TestCase
         $this->assertGreaterThan($minimumLanguageCount, count($availableLanguages));
 
         // Verify some common aliases/names are present.
-        $this->assertEquals(true, in_array('yaml', $availableLanguages));
-        $this->assertEquals(true, in_array('yml', $availableLanguages));
-        $this->assertEquals(true, in_array('c++', $availableLanguages));
-        $this->assertEquals(true, in_array('cpp', $availableLanguages));
+        $this->assertContains('yaml', $availableLanguages);
+        $this->assertContains('yml', $availableLanguages);
+        $this->assertContains('c++', $availableLanguages);
+        $this->assertContains('cpp', $availableLanguages);
     }
 
     public function testGetAliasesForLanguageWhenUsingMainLanguageName()

--- a/test/HighlightTest.php
+++ b/test/HighlightTest.php
@@ -83,6 +83,22 @@ class HighlightTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected_aliases, $aliases);
     }
 
+    public function testGetAliasesForLanguageWhenLanguageHasNoAliases()
+    {
+        $languageDefinitionFile = __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR .
+                                'Highlight' . DIRECTORY_SEPARATOR . 'languages' . DIRECTORY_SEPARATOR . "ada.json";
+        $language = new Language('ada', $languageDefinitionFile);
+        $expected_aliases = $language->aliases;
+        $expected_aliases[] = 'ada';
+        sort($expected_aliases);
+
+        $hl = new Highlighter();
+        $aliases = $hl->getAliasesForLanguage('ada');
+        sort($aliases);
+
+        $this->assertEquals($expected_aliases, $aliases);
+    }
+
     public function testGetAliasesForLanguageWhenUsingLanguageAlias()
     {
         $languageDefinitionFile = __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR .

--- a/test/HighlightTest.php
+++ b/test/HighlightTest.php
@@ -31,6 +31,8 @@
 use Highlight\Highlighter;
 use Highlight\Language;
 
+use Symfony\Component\Finder\Finder;
+
 class HighlightTest extends PHPUnit_Framework_TestCase
 {
     public function testUnknownLanguageThrowsDomainException()
@@ -43,9 +45,8 @@ class HighlightTest extends PHPUnit_Framework_TestCase
 
     public function testListLanguagesWithoutAliases()
     {
-        $expectedLanguageCount = count(glob(__DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR .
-                                            'Highlight' . DIRECTORY_SEPARATOR . 'languages' . DIRECTORY_SEPARATOR .
-                                            '*.json'));
+        $languageFinder = new Finder();
+        $expectedLanguageCount = $languageFinder->in(__DIR__ . '/../Highlight/languages/')->name('*.json')->count();
 
         $hl = new Highlighter();
 
@@ -58,13 +59,19 @@ class HighlightTest extends PHPUnit_Framework_TestCase
 
     public function testListLanguagesWithAliases()
     {
-        $minimumLanguageCount = count(glob(__DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR .
-                                           'Highlight' . DIRECTORY_SEPARATOR . 'languages' . DIRECTORY_SEPARATOR .
-                                           '*.json'));
+        $languageFinder = new Finder();
+        $minimumLanguageCount = $languageFinder->in(__DIR__ . '/../Highlight/languages/')->name('*.json')->count();
 
         $hl = new Highlighter();
         $availableLanguages = $hl->listLanguages(true);
+
         $this->assertGreaterThan($minimumLanguageCount, count($availableLanguages));
+
+        // Verify some common aliases/names are present.
+        $this->assertEquals(true, in_array('yaml', $availableLanguages));
+        $this->assertEquals(true, in_array('yml', $availableLanguages));
+        $this->assertEquals(true, in_array('c++', $availableLanguages));
+        $this->assertEquals(true, in_array('cpp', $availableLanguages));
     }
 
     public function testGetAliasesForLanguageWhenUsingMainLanguageName()


### PR DESCRIPTION
The purpose of this PR is to introduce ability to access information about the available language aliases via the `Highligther` class instances.

This can be particularly helpful in web applications if presenting user with a drop-down list of syntaxes to choose from.

Although the normalised names should be quite helpful, they can sometimes also be a bit confusing, for example the `html` language is merely an alias for `xml`. This is not super-obvious to most users (and in fact for a while I thought the library had no HTML syntax highlighting myself).

I've also tried to implement tests for methods that got changed/added to help with regression testing.

All input is welcome, so if you think something needs to be changed/improved, do let me know - especially since PHP is not something I delve into on regular basis :)