### PR TITLE
Improvements to register custom languages

### DIFF
--- a/Highlight/Highlighter.php
+++ b/Highlight/Highlighter.php
@@ -64,17 +64,17 @@ class Highlighter
             'languages' => null,
         );
 
-        $this->registerLanguages();
+        self::registerLanguages();
     }
 
-    private function registerLanguages()
+    private static function registerLanguages()
     {
         // Languages that take precedence in the classMap array.
         $languagePath = __DIR__ . DIRECTORY_SEPARATOR . "languages" . DIRECTORY_SEPARATOR;
         foreach (array("xml", "django", "javascript", "matlab", "cpp") as $languageId) {
             $filePath = $languagePath . $languageId . ".json";
             if (is_readable($filePath)) {
-                $this->registerLanguage($languageId, $filePath);
+                self::registerLanguage($languageId, $filePath);
             }
         }
 
@@ -85,7 +85,7 @@ class Highlighter
                     $languageId = substr($entry, 0, -5);
                     $filePath = $languagePath . $entry;
                     if (is_readable($filePath)) {
-                        $this->registerLanguage($languageId, $filePath);
+                        self::registerLanguage($languageId, $filePath);
                     }
                 }
             }
@@ -376,7 +376,7 @@ class Highlighter
     public function setAutodetectLanguages(array $set)
     {
         $this->autodetectSet = array_unique($set);
-        $this->registerLanguages();
+        self::registerLanguages();
     }
 
     /**

--- a/Highlight/Highlighter.php
+++ b/Highlight/Highlighter.php
@@ -70,9 +70,9 @@ class Highlighter
     private function registerLanguages()
     {
         // Languages that take precedence in the classMap array.
-        $languagePath = __DIR__.DIRECTORY_SEPARATOR."languages".DIRECTORY_SEPARATOR;
+        $languagePath = __DIR__ . DIRECTORY_SEPARATOR . "languages" . DIRECTORY_SEPARATOR;
         foreach (array("xml", "django", "javascript", "matlab", "cpp") as $languageId) {
-            $filePath = $languagePath.$languageId.".json";
+            $filePath = $languagePath . $languageId . ".json";
             if (is_readable($filePath)) {
                 $this->registerLanguage($languageId, $filePath);
             }
@@ -80,10 +80,10 @@ class Highlighter
 
         $d = @dir($languagePath);
         if ($d) {
-            while (false !== ($entry = $d->read())) {
+            while (($entry = $d->read()) !== false) {
                 if (substr($entry, -5) === ".json") {
                     $languageId = substr($entry, 0, -5);
-                    $filePath = $languagePath.$entry;
+                    $filePath = $languagePath . $entry;
                     if (is_readable($filePath)) {
                         $this->registerLanguage($languageId, $filePath);
                     }
@@ -102,7 +102,7 @@ class Highlighter
      *
      * @param string $languageId The unique name of a language
      * @param string $filePath   The file path to the language definition
-     * @param bool $overwrite    Overwrite language if it already exists
+     * @param bool   $overwrite  Overwrite language if it already exists
      *
      * @return Language The object containing the definition for a language's markup
      */

--- a/Highlight/Highlighter.php
+++ b/Highlight/Highlighter.php
@@ -71,9 +71,11 @@ class Highlighter
     {
         // Languages that take precedence in the classMap array.
         $languagePath = __DIR__.DIRECTORY_SEPARATOR."languages".DIRECTORY_SEPARATOR;
-        foreach(Array("xml", "django", "javascript", "matlab", "cpp") as $languageId) {
+        foreach (array("xml", "django", "javascript", "matlab", "cpp") as $languageId) {
             $filePath = $languagePath.$languageId.".json";
-            if (is_readable($filePath)) $this->registerLanguage($languageId, $filePath);
+            if (is_readable($filePath)) {
+                $this->registerLanguage($languageId, $filePath);
+            }
         }
 
         $d = @dir($languagePath);
@@ -82,7 +84,9 @@ class Highlighter
                 if (substr($entry, -5) === ".json") {
                     $languageId = substr($entry, 0, -5);
                     $filePath = $languagePath.$entry;
-                    if (is_readable($filePath)) $this->registerLanguage($languageId, $filePath);
+                    if (is_readable($filePath)) {
+                        $this->registerLanguage($languageId, $filePath);
+                    }
                 }
             }
             $d->close();

--- a/Highlight/Highlighter.php
+++ b/Highlight/Highlighter.php
@@ -63,63 +63,54 @@ class Highlighter
             'useBR' => false,
             'languages' => null,
         );
-
-        $this->registerLanguages();
+        if (self::$languages === null) $this->registerLanguages();
     }
 
     private function registerLanguages()
     {
         // Languages that take precedence in the classMap array.
-        foreach (array("xml", "django", "javascript", "matlab", "cpp") as $l) {
-            $this->createLanguage($l);
+        $languagePath = __DIR__.DIRECTORY_SEPARATOR."languages".DIRECTORY_SEPARATOR;
+        foreach(Array("xml", "django", "javascript", "matlab", "cpp") as $languageId) {
+            $filePath = $languagePath.$l.".json";
+            if (is_readable($filePath)) $this->registerLanguage($languageId, $filePath);
         }
 
-        $d = dir(__DIR__ . DIRECTORY_SEPARATOR . "languages");
-        while (($entry = $d->read()) !== false) {
-            if ($entry[0] !== ".") {
-                $lng = substr($entry, 0, -5);
-                $this->createLanguage($lng);
+        $d = @dir($languagePath);
+        if ($d) {
+            while (false !== ($entry = $d->read())) {
+                if (substr($entry, -5) === ".json") {
+                    $languageId = substr($entry, 0, -5);
+                    $filePath = $languagePath.$entry;
+                    if (is_readable($filePath)) $this->registerLanguage($languageId, $filePath);
+                }
             }
+            $d->close();
         }
-        $d->close();
 
         self::$languages = array_keys(self::$classMap);
     }
 
-    private function createLanguage($languageId)
-    {
-        if (!isset(self::$classMap[$languageId])) {
-            self::registerLanguage(
-                $languageId,
-                __DIR__ . DIRECTORY_SEPARATOR . "languages" . DIRECTORY_SEPARATOR . "$languageId.json"
-            );
-        }
-
-        return self::$classMap[$languageId];
-    }
-
     /**
      * Register a language definition with the Highlighter's internal language
-     * storage.
+     * storage. Languages are stored in a static variable, so they'll be available
+     * across all instances. You only need to register a language once.
      *
-     * - If a language with the same $languageID already exists, it will be
-     *   overwritten.
-     * - Languages are stored in a static variable, so they'll be available
-     *   across all instances. You only need to register a language once.
-     *
-     * @param string $languageId       The unique name of a language
-     * @param string $absoluteFilePath The file path to the language definition
+     * @param string $languageId The unique name of a language
+     * @param string $filePath   The file path to the language definition
+     * @param bool $overwrite    Overwrite language if it already exists
      *
      * @return Language The object containing the definition for a language's markup
      */
-    public static function registerLanguage($languageId, $absoluteFilePath)
+    public static function registerLanguage($languageId, $filePath, $overwrite = false)
     {
-        $lang = new Language($languageId, $absoluteFilePath);
-        self::$classMap[$languageId] = $lang;
+        if (!isset(self::$classMap[$languageId]) || $overwrite) {
+            $lang = new Language($languageId, $filePath);
+            self::$classMap[$languageId] = $lang;
 
-        if (isset($lang->mode->aliases)) {
-            foreach ($lang->mode->aliases as $alias) {
-                self::$aliases[$alias] = $languageId;
+            if (isset($lang->mode->aliases)) {
+                foreach ($lang->mode->aliases as $alias) {
+                    self::$aliases[$alias] = $languageId;
+                }
             }
         }
 

--- a/Highlight/Highlighter.php
+++ b/Highlight/Highlighter.php
@@ -63,7 +63,8 @@ class Highlighter
             'useBR' => false,
             'languages' => null,
         );
-        if (self::$languages === null) $this->registerLanguages();
+
+        $this->registerLanguages();
     }
 
     private function registerLanguages()

--- a/Highlight/Highlighter.php
+++ b/Highlight/Highlighter.php
@@ -71,7 +71,7 @@ class Highlighter
         // Languages that take precedence in the classMap array.
         $languagePath = __DIR__.DIRECTORY_SEPARATOR."languages".DIRECTORY_SEPARATOR;
         foreach(Array("xml", "django", "javascript", "matlab", "cpp") as $languageId) {
-            $filePath = $languagePath.$l.".json";
+            $filePath = $languagePath.$languageId.".json";
             if (is_readable($filePath)) $this->registerLanguage($languageId, $filePath);
         }
 


### PR DESCRIPTION
Hi, this pull request changes two things. First `function registerLanguages()` will only register files that exist. This allows you to have as few files in the language folder as you need. Second `function registerLanguage()` has a new argument. This allows you to register custom files in the same way as the automatic registration, the default is to not overwrite language definition in the internal storage. 

What problem does this solve? It should give you a bit flexibility and a performance improvement, in case you register custom files with `registerLanguage()`. For example a large API documentation on my computer (MacBook, PHP 7.1.16) took 200 ms to generate before, 120 ms after.

I am really impressed how fast this syntax highlighter works. The API documentation mentioned above previously took 850 ms to generate with another syntax highlighter. Great work. 👍 