### PR TITLE
Fix UTF8 support in splitCodeIntoArray()

### DIFF
--- a/HighlightUtilities/functions.php
+++ b/HighlightUtilities/functions.php
@@ -175,7 +175,8 @@ function splitCodeIntoArray($html)
 
     $dom = new \DOMDocument();
 
-    if (!$dom->loadHTML($html)) {
+    // https://stackoverflow.com/a/8218649
+    if (!$dom->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'))) {
         throw new \UnexpectedValueException("The given HTML could not be parsed correctly.");
     }
 
@@ -186,9 +187,9 @@ function splitCodeIntoArray($html)
         $classes = $span->getAttribute("class");
         $renderedSpan = $dom->saveHTML($span);
 
-        if (preg_match('/\R/', $renderedSpan)) {
+        if (preg_match('/\R/u', $renderedSpan)) {
             $finished = preg_replace(
-                '/\R/',
+                '/\R/u',
                 sprintf('</span>%s<span class="%s">', PHP_EOL, $classes),
                 $renderedSpan
             );
@@ -196,5 +197,5 @@ function splitCodeIntoArray($html)
         }
     }
 
-    return preg_split('/\R/', $html);
+    return preg_split('/\R/u', $html);
 }

--- a/test/HighlightUtilitiesTest.php
+++ b/test/HighlightUtilitiesTest.php
@@ -128,11 +128,11 @@ PHP;
 
         $this->assertEquals(
             $split,
-            [
+            array(
                 '<span class="hljs-comment">// ✅ ...</span>',
                 '$user = <span class="hljs-keyword">new</span> \stdClass();',
-                '$isUserPending = $user-&gt;isStatus(<span class="hljs-string">\'pending\'</span>);'
-            ]
+                '$isUserPending = $user-&gt;isStatus(<span class="hljs-string">\'pending\'</span>);',
+            )
         );
     }
 

--- a/test/HighlightUtilitiesTest.php
+++ b/test/HighlightUtilitiesTest.php
@@ -116,6 +116,26 @@ PHP;
         }
     }
 
+    public function testSplitCodeIntoArray_Emojis()
+    {
+        $raw = <<<'PHP'
+// ✅ ...
+$user = new \stdClass();
+$isUserPending = $user->isStatus('pending');
+PHP;
+        $highlighted = $this->hl->highlight('php', $raw);
+        $split = \HighlightUtilities\splitCodeIntoArray($highlighted->value);
+
+        $this->assertEquals(
+            $split,
+            [
+                '<span class="hljs-comment">// ✅ ...</span>',
+                '$user = <span class="hljs-keyword">new</span> \stdClass();',
+                '$isUserPending = $user-&gt;isStatus(<span class="hljs-string">\'pending\'</span>);'
+            ]
+        );
+    }
+
     public function testGetThemeBackgroundColorSingleColor()
     {
         $theme = 'atom-one-dark';


### PR DESCRIPTION
The `splitCodeIntoArray()` utility function did not support UTF-8 and would break things. Considering that the rest of this library supports UTF-8, our split utility should too.