### PR TITLE
Fix splitCodeIntoArray when it has nested spans + newlines

### DIFF
--- a/HighlightUtilities/functions.php
+++ b/HighlightUtilities/functions.php
@@ -176,25 +176,38 @@ function splitCodeIntoArray($html)
     $dom = new \DOMDocument();
 
     // https://stackoverflow.com/a/8218649
-    if (!$dom->loadHTML(mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8'))) {
+    if (!$dom->loadHTML(mb_convert_encoding($html, "HTML-ENTITIES", "UTF-8"))) {
         throw new \UnexpectedValueException("The given HTML could not be parsed correctly.");
     }
 
-    $spans = $dom->getElementsByTagName("span");
+    $xpath = new \DOMXPath($dom);
+    $spans = $xpath->query("//span[contains(text(), '\n') or contains(text(), '\r\n')]");
 
     /** @var \DOMElement $span */
     foreach ($spans as $span) {
-        $classes = $span->getAttribute("class");
-        $renderedSpan = $dom->saveHTML($span);
+        $classes = [];
+        $curr = $span;
 
-        if (preg_match('/\R/u', $renderedSpan)) {
-            $finished = preg_replace(
-                '/\R/u',
-                sprintf('</span>%s<span class="%s">', PHP_EOL, $classes),
-                $renderedSpan
-            );
-            $html = str_replace($renderedSpan, $finished, $html);
+        while ($curr->tagName === 'span') {
+            $classes[] = $curr->getAttribute("class");
+            $curr = $curr->parentNode;
         }
+
+        $renderedSpan = $dom->saveHTML($span);
+        $closingTags = '';
+        $openingTags = '';
+
+        foreach ($classes as $class) {
+            $closingTags .= '</span>';
+            $openingTags = sprintf('<span class="%s">%s', $class, $openingTags);
+        }
+
+        $finished = preg_replace(
+            '/\R/u',
+            $closingTags . PHP_EOL . $openingTags,
+            $renderedSpan
+        );
+        $html = str_replace($renderedSpan, $finished, $html);
     }
 
     return preg_split('/\R/u', $html);

--- a/HighlightUtilities/functions.php
+++ b/HighlightUtilities/functions.php
@@ -185,23 +185,18 @@ function splitCodeIntoArray($html)
 
     /** @var \DOMElement $span */
     foreach ($spans as $span) {
-        $classes = [];
+        $closingTags = '';
+        $openingTags = '';
         $curr = $span;
 
         while ($curr->tagName === 'span') {
-            $classes[] = $curr->getAttribute("class");
+            $closingTags .= '</span>';
+            $openingTags = sprintf('<span class="%s">%s', $curr->getAttribute("class"), $openingTags);
+
             $curr = $curr->parentNode;
         }
 
         $renderedSpan = $dom->saveHTML($span);
-        $closingTags = '';
-        $openingTags = '';
-
-        foreach ($classes as $class) {
-            $closingTags .= '</span>';
-            $openingTags = sprintf('<span class="%s">%s', $class, $openingTags);
-        }
-
         $finished = preg_replace(
             '/\R/u',
             $closingTags . PHP_EOL . $openingTags,

--- a/test/HighlightUtilitiesTest.php
+++ b/test/HighlightUtilitiesTest.php
@@ -154,6 +154,22 @@ JAVA;
         );
     }
 
+    public function testSplitCodeIntoArray_DeeplyNestedSpansCRLF()
+    {
+        $raw = "public QuoteEntity(\r\n)";
+
+        $highlighted = $this->hl->highlight('java', $raw);
+        $split = \HighlightUtilities\splitCodeIntoArray($highlighted->value);
+
+        $this->assertEquals(
+            $split,
+            array(
+                '<span class="hljs-function"><span class="hljs-keyword">public</span> <span class="hljs-title">QuoteEntity</span><span class="hljs-params">(</span></span>',
+                '<span class="hljs-function"><span class="hljs-params">)</span></span>',
+            )
+        );
+    }
+
     public function testGetThemeBackgroundColorSingleColor()
     {
         $theme = 'atom-one-dark';

--- a/test/HighlightUtilitiesTest.php
+++ b/test/HighlightUtilitiesTest.php
@@ -136,6 +136,24 @@ PHP;
         );
     }
 
+    public function testSplitCodeIntoArray_DeeplyNestedSpans()
+    {
+        $raw = <<<'JAVA'
+public QuoteEntity(
+)
+JAVA;
+        $highlighted = $this->hl->highlight('java', $raw);
+        $split = \HighlightUtilities\splitCodeIntoArray($highlighted->value);
+
+        $this->assertEquals(
+            $split,
+            array(
+                '<span class="hljs-function"><span class="hljs-keyword">public</span> <span class="hljs-title">QuoteEntity</span><span class="hljs-params">(</span></span>',
+                '<span class="hljs-function"><span class="hljs-params">)</span></span>',
+            )
+        );
+    }
+
     public function testGetThemeBackgroundColorSingleColor()
     {
         $theme = 'atom-one-dark';


### PR DESCRIPTION
The `splitCodeIntoArray` function was generating broken HTML when there were deeply nested `\n` characters because it wasn't closing the correct number of `<span>` tags.

~~Marking this as a draft to see what the performance impact is by using XPath.~~

Originally, `splitCodeIntoArray` was working off the assumption that `<span>`s would only nest one level deep when splitting on new lines. Notice the `span.hljs-params` element is a child to `span.hljs-function`. Because of this assumption, we were closing the `hljs-params` span but not the `hljs-function` span.

Output from `highlight`

```html
<span class="hljs-function"><span class="hljs-keyword">public</span> <span class="hljs-title">QuoteEntity</span><span class="hljs-params">(
)</span></span>
```

Current `splitCodeIntoArray` output:

```html
<span class="hljs-function"><span class="hljs-keyword">public</span> <span class="hljs-title">QuoteEntity</span><span class="hljs-params">(</span>
<span class="hljs-params">)</span></span>
```

What it **should** look like (fix in this PR):

```html
<span class="hljs-function"><span class="hljs-keyword">public</span> <span class="hljs-title">QuoteEntity</span><span class="hljs-params">(</span></span>
<span class="hljs-function"><span class="hljs-params">)</span></span>
```


See https://github.com/westonruter/syntax-highlighting-code-block/issues/193