### PR TITLE
Exit out early when empty string is split

### DIFF
--- a/HighlightUtilities/functions.php
+++ b/HighlightUtilities/functions.php
@@ -173,6 +173,10 @@ function splitCodeIntoArray($html)
         throw new \RuntimeException("The DOM extension is not loaded but is required.");
     }
 
+    if (trim($html) === "") {
+        return array();
+    }
+
     $dom = new \DOMDocument();
 
     // https://stackoverflow.com/a/8218649

--- a/test/HighlightUtilitiesTest.php
+++ b/test/HighlightUtilitiesTest.php
@@ -170,6 +170,23 @@ JAVA;
         );
     }
 
+    public static function dataProvider_emptyStrings()
+    {
+        return array(
+            array(""),
+            array("\t"),
+            array("  "),
+        );
+    }
+
+    /**
+     * @dataProvider dataProvider_emptyStrings
+     */
+    public function testSplitCodeIntoArray_EmptyString($string)
+    {
+        $this->assertEquals(array(), \HighlightUtilities\splitCodeIntoArray($string));
+    }
+
     public function testGetThemeBackgroundColorSingleColor()
     {
         $theme = 'atom-one-dark';


### PR DESCRIPTION
When `splitCodeIntoArray()` is given an empty string, we shouldn't be throwing a warning.

See https://github.com/westonruter/syntax-highlighting-code-block/issues/189