### PR TITLE
Correct `{@inheritdoc}` to `@inheritDoc` in doc blocks

### DIFF
--- a/src/Highlight/RegExMatch.php
+++ b/src/Highlight/RegExMatch.php
@@ -57,7 +57,7 @@ class RegExMatch implements \ArrayAccess, \Countable, \IteratorAggregate
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function getIterator()
     {
@@ -65,7 +65,7 @@ class RegExMatch implements \ArrayAccess, \Countable, \IteratorAggregate
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function offsetExists($offset)
     {
@@ -73,7 +73,7 @@ class RegExMatch implements \ArrayAccess, \Countable, \IteratorAggregate
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function offsetGet($offset)
     {
@@ -81,7 +81,7 @@ class RegExMatch implements \ArrayAccess, \Countable, \IteratorAggregate
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function offsetSet($offset, $value)
     {
@@ -89,7 +89,7 @@ class RegExMatch implements \ArrayAccess, \Countable, \IteratorAggregate
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      */
     public function offsetUnset($offset)
     {
@@ -97,7 +97,7 @@ class RegExMatch implements \ArrayAccess, \Countable, \IteratorAggregate
     }
 
     /**
-     * {@inheritdoc}
+     * @inheritDoc
      *
      * @return int
      */


### PR DESCRIPTION
Minor issue, but for Hacktoberfest, I thought I would correct it.

{@inheritdoc} should be @inheritDoc

See [Inheritance](https://docs.phpdoc.org/latest/guides/inheritance.html)

Also, feel free to link to your full source code docs at [PHPFUI/InstaDoc/Highlight](http://www.phpfui.com/?n=Highlight).  I use it to highlight the PHP code.