### PR TITLE
Fix the atrocious performance of matching regexes after 9.16.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
       fail-fast: false
       matrix:
         php-versions:
+          - '5.4'
+          - '5.5'
           - '5.6'
           - '7.0'
           - '7.1'

--- a/Highlight/RegEx.php
+++ b/Highlight/RegEx.php
@@ -76,13 +76,13 @@ final class RegEx
     {
         $index = null;
         $results = array();
-        preg_match_all($this->source, $str, $results, PREG_SET_ORDER | PREG_OFFSET_CAPTURE, $this->lastIndex);
+        preg_match($this->source, $str, $results, PREG_OFFSET_CAPTURE, $this->lastIndex);
 
         if ($results === null || count($results) === 0) {
             return null;
         }
 
-        foreach ($results[0] as &$result) {
+        foreach ($results as &$result) {
             if ($result[1] !== -1) {
                 // Only save the index if it hasn't been set yet
                 if ($index === null) {
@@ -95,7 +95,8 @@ final class RegEx
             }
         }
 
-        $results = $results[0];
+        unset($result);
+
         $this->lastIndex += mb_strlen($results[0]) + ($index - $this->lastIndex);
 
         $matches = new RegExMatch($results);


### PR DESCRIPTION
In 9.16, I introduced the `RegEx` class in order to keep the PHP code aesthetically close to what the JS equivalent would be. However, the performance for `RegEx` was atrocious because instead of stopping after the first match, it continued moving on to find all of the matches (`preg_match` vs `preg_match_all`).

This PR fixes the atrocious performance but doesn't quite match the performance seen in 9.15 and below. I'm currently seeing **0.15 seconds** with this PR where 9.15 had **0.09 seconds**. The difference is... fairly negligible compared to the **40 second** time currently in 9.18.

Fixes #78