### PR TITLE
More fixes for Unicode support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,3 +104,9 @@ The process of bringing in languages from highlight.js has been put into a singl
 cd tools
 bash process.sh
 ```
+
+## Why don't we generally use `mb_*` functions?
+
+PHP offers `mb_` prefixed string functions to support multi-byte strings, this means supporting unicode characters. However, the PREG functions in PHP calculate [string lengths and positions in _bytes_, and not character lengths](https://www.php.net/manual/en/function.preg-match.php#refsect1-function.preg-match-parameters). For that reason, we will generally **not** use the multi-byte variants of string functions; there are exceptions to this policy.
+
+An exception to this policy is the use of functions that aren't used for calculating string lengths or positions; e.g. `mb_strtolower`.

--- a/Highlight/Highlighter.php
+++ b/Highlight/Highlighter.php
@@ -328,7 +328,7 @@ class Highlighter
      */
     private function keywordMatch($mode, $match)
     {
-        $kwd = $this->language->case_insensitive ? mb_strtolower($match[0], "UTF-8") : $match[0];
+        $kwd = $this->language->case_insensitive ? mb_strtolower($match[0]) : $match[0];
 
         return isset($mode->keywords[$kwd]) ? $mode->keywords[$kwd] : null;
     }

--- a/Highlight/RegEx.php
+++ b/Highlight/RegEx.php
@@ -97,7 +97,7 @@ final class RegEx
 
         unset($result);
 
-        $this->lastIndex += mb_strlen($results[0]) + ($index - $this->lastIndex);
+        $this->lastIndex += strlen($results[0]) + ($index - $this->lastIndex);
 
         $matches = new RegExMatch($results);
         $matches->index = isset($index) ? $index : 0;

--- a/test/UnicodeTest.php
+++ b/test/UnicodeTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use Highlight\Highlighter;
+
+class UnicodeTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var Highlighter */
+    private $hl;
+
+    protected function setUp()
+    {
+        $this->hl = new Highlighter();
+    }
+
+    public function testUnicodeCharacters()
+    {
+        $raw = <<<CSTYLE
+if (FELTÉTEL)
+{
+  IGAZ ÁG
+}
+else
+{
+  HAMIS ÁG
+}
+CSTYLE;
+        $result = $this->hl->highlight('c', $raw)->value;
+        $expected = <<<EXPECTED
+<span class="hljs-keyword">if</span> (FELTÉTEL)
+{
+  IGAZ ÁG
+}
+<span class="hljs-keyword">else</span>
+{
+  HAMIS ÁG
+}
+EXPECTED;
+
+        $this->assertEquals($expected, $result);
+    }
+}


### PR DESCRIPTION
Because Unicode support is hard, here's another PR. It also helps to understand how PHP handles UTF-8. All PREG-related functions in PHP will calculate string offsets in _bytes_ and **not** character lengths; this causes problems because `mb_*` functions use character lengths.

This also means #88 will need to be reevaluated whenever I get a chance.

Reported in https://github.com/westonruter/syntax-highlighting-code-block/issues/400

/cc @westonruter