### PR TITLE
Php8.1 v9

### DIFF
--- a/Highlight/RegExMatch.php
+++ b/Highlight/RegExMatch.php
@@ -59,6 +59,7 @@ class RegExMatch implements \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \ArrayIterator($this->data);
@@ -67,6 +68,7 @@ class RegExMatch implements \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->data[$offset]);
@@ -75,6 +77,7 @@ class RegExMatch implements \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->data[$offset];
@@ -83,6 +86,7 @@ class RegExMatch implements \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         throw new \LogicException(__CLASS__ . ' instances are read-only.');
@@ -91,6 +95,7 @@ class RegExMatch implements \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         throw new \LogicException(__CLASS__ . ' instances are read-only.');
@@ -101,6 +106,7 @@ class RegExMatch implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->data);


### PR DESCRIPTION
This is the V9 compatible version.

PHP 8.1 needs #[\ReturnTypeWillChange] on classes that implement \ArrayAccess, \Countable, or \IteratorAggregate

As this is a comment in pre 8.1 versions, it is completely backward compatible. In PHP 8.1, it prevents a depreciation notice.

It would be nice to merge quickly and create a new version that is 8.1 compatible.

Thanks!