### PR TITLE
Declare previous dynamic properties

### DIFF
--- a/src/Highlight/RegExMatch.php
+++ b/src/Highlight/RegExMatch.php
@@ -48,6 +48,12 @@ class RegExMatch implements \ArrayAccess, \Countable, \IteratorAggregate
     /** @var string */
     public $input;
 
+    /** @var string */
+    public $type;
+
+    /** @var Mode|string */
+    public $rule;
+
     /**
      * @param array<int, string|null> $results
      */

--- a/src/Highlight/Terminators.php
+++ b/src/Highlight/Terminators.php
@@ -111,7 +111,6 @@ final class Terminators
 
         if (is_string($rule)) {
             $match->type = $rule;
-            $match->extra = array($this->mode->illegal, $this->mode->terminator_end);
         } else {
             $match->type = "begin";
             $match->rule = $rule;


### PR DESCRIPTION
Simple fix for PHP 8.2 is to declare previous dynamic properties.

Looks like tests are so out of date that older versions don't seem to work.  I would suggest dropping support for anything below 7.4, as it is just not worth the support headache.  They can use version 9.

Also looks like the tests will need some work to bring them up to modern standards.  Happy to help here, just want to make sure you are up for modernizing the package.