### PR TITLE
Declare previous dynamic properties

### DIFF
--- a/Highlight/RegExMatch.php
+++ b/Highlight/RegExMatch.php
@@ -48,6 +48,12 @@ class RegExMatch implements \ArrayAccess, \Countable, \IteratorAggregate
     /** @var string */
     public $input;
 
+    /** @var string */
+    public $type;
+
+    /** @var Mode|string */
+    public $rule;
+
     /**
      * @param array<int, string|null> $results
      */

--- a/Highlight/Terminators.php
+++ b/Highlight/Terminators.php
@@ -111,7 +111,6 @@ final class Terminators
 
         if (is_string($rule)) {
             $match->type = $rule;
-            $match->extra = array($this->mode->illegal, $this->mode->terminator_end);
         } else {
             $match->type = "begin";
             $match->rule = $rule;


### PR DESCRIPTION
PHP 8.2 fix for V9

There may be some failed tests.  I can't run versions of PHP from the late Ming Dynasty on my machine, but the code should be PHP 5 compatible.